### PR TITLE
Add updateOnDrag parameter for Line Chart

### DIFF
--- a/charts/src/main/java/hu/ma/charts/line/LineChart.kt
+++ b/charts/src/main/java/hu/ma/charts/line/LineChart.kt
@@ -175,9 +175,8 @@ fun LineChart(
                           val snapToPoint =
                             snapToPoints(xinterval, drillDownPoint ?: 0f, data.series)
                           if (snapToPoint != null && snapToPoint.x != lastSnapToPointX) {
-                            drillDownPoint = (snapToPoint.x) * xinterval
-                            onDrillDown(snapToPoint.x, data.series)
-                            lastSnapToPointX = snapToPoint.x
+                              onDrillDown(snapToPoint.x, data.series)
+                              lastSnapToPointX = snapToPoint.x
                           }
                         }
                       }

--- a/charts/src/main/java/hu/ma/charts/line/LineChart.kt
+++ b/charts/src/main/java/hu/ma/charts/line/LineChart.kt
@@ -68,7 +68,7 @@ fun LineChart(
   )? = { position, entries ->
     LinesChartLegend(position = position, entries = entries)
   },
-  updateOnDrag: Boolean = false,
+  callDrilldownCallbackOnDrag: Boolean = false,
 ) {
   val legendEntries = remember(data) { data.createLegendEntries(data.legendShapeSize) }
 
@@ -170,7 +170,7 @@ fun LineChart(
                     onHorizontalDrag = { change, _ ->
                       if (change.position.x >= 0 && change.position.x <= maxWidth.toPx()) {
                         drillDownPoint = change.position.x
-                        if (updateOnDrag) {
+                        if (callDrilldownCallbackOnDrag) {
                           val xinterval = maxWidth.toPx() / maxNumberOfPointsOnX
                           val snapToPoint =
                             snapToPoints(xinterval, drillDownPoint ?: 0f, data.series)

--- a/charts/src/main/java/hu/ma/charts/line/LineChart.kt
+++ b/charts/src/main/java/hu/ma/charts/line/LineChart.kt
@@ -175,8 +175,8 @@ fun LineChart(
                           val snapToPoint =
                             snapToPoints(xinterval, drillDownPoint ?: 0f, data.series)
                           if (snapToPoint != null && snapToPoint.x != lastSnapToPointX) {
-                              onDrillDown(snapToPoint.x, data.series)
-                              lastSnapToPointX = snapToPoint.x
+                            onDrillDown(snapToPoint.x, data.series)
+                            lastSnapToPointX = snapToPoint.x
                           }
                         }
                       }


### PR DESCRIPTION
Add feature for updating values of actual point from chart when dragging over the line chart.

Use case example: Showing actual data from chart meanwhile you dragging over the line chart.